### PR TITLE
Initialize Go module with Cobra CLI

### DIFF
--- a/cmd/kvasx/main.go
+++ b/cmd/kvasx/main.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	cfgPath  string
+	logLevel string
+)
+
+func main() {
+	rootCmd := &cobra.Command{
+		Use:   "kvasx",
+		Short: "kvasx is a CLI tool",
+	}
+
+	rootCmd.PersistentFlags().StringVar(&cfgPath, "config", "", "Path to config file")
+	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "info", "Logging level")
+
+	dnsCmd := &cobra.Command{
+		Use:   "dns",
+		Short: "DNS related commands",
+	}
+
+	dnsStatusCmd := &cobra.Command{
+		Use:   "status",
+		Short: "Show DNS status",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println("DNS status: OK")
+		},
+	}
+
+	dnsCmd.AddCommand(dnsStatusCmd)
+	rootCmd.AddCommand(dnsCmd)
+
+	rootCmd.AddCommand(&cobra.Command{
+		Use:   "vpn",
+		Short: "VPN related commands",
+	})
+	rootCmd.AddCommand(&cobra.Command{
+		Use:   "adblock",
+		Short: "Adblock related commands",
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module kvasx
+
+go 1.24.3
+
+require github.com/spf13/cobra v1.9.1
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.6 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
+github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
+github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
+github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
## Summary
- initialize `kvasx` Go module
- add Cobra-based CLI with global flags
- implement `dns status` example subcommand

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689a2cba69388332b6ef7f463150fdd0