### PR TITLE
feat: add dns management

### DIFF
--- a/cmd/kvasx/main.go
+++ b/cmd/kvasx/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"kvasx/pkg/dns"
 	"kvasx/pkg/ipset"
 	"kvasx/pkg/route"
 )
@@ -37,7 +38,17 @@ func main() {
 		},
 	}
 
+	dnsSetCmd := &cobra.Command{
+		Use:   "set <server>",
+		Short: "Set upstream DNS server",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return dns.SetServer(args[0])
+		},
+	}
+
 	dnsCmd.AddCommand(dnsStatusCmd)
+	dnsCmd.AddCommand(dnsSetCmd)
 	rootCmd.AddCommand(dnsCmd)
 
 	vpnCmd := &cobra.Command{
@@ -75,11 +86,6 @@ func main() {
 	}
 	ipsetCmd.AddCommand(ipsetAddCmd)
 	rootCmd.AddCommand(ipsetCmd)
-
-	rootCmd.AddCommand(&cobra.Command{
-		Use:   "adblock",
-		Short: "Adblock related commands",
-	})
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -1,0 +1,95 @@
+package dns
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+const (
+	// ConfigFile is the dnsmasq configuration file managed by kvasx
+	ConfigFile = "/etc/dnsmasq.d/kvasx.conf"
+)
+
+// GenerateHosts creates a hosts file from the provided domain to IP mapping.
+// Each entry is written as "IP domain" which is the format expected by dnsmasq.
+func GenerateHosts(entries map[string]string, path string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	w := bufio.NewWriter(f)
+	for host, ip := range entries {
+		if _, err := fmt.Fprintf(w, "%s %s\n", ip, host); err != nil {
+			return err
+		}
+	}
+	return w.Flush()
+}
+
+// GenerateIPSet writes dnsmasq ipset configuration file. Each domain is mapped
+// to the provided ipset name.
+func GenerateIPSet(domains []string, setName, path string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	w := bufio.NewWriter(f)
+	for _, d := range domains {
+		if _, err := fmt.Fprintf(w, "ipset=/%s/%s\n", d, setName); err != nil {
+			return err
+		}
+	}
+	return w.Flush()
+}
+
+// SetServer updates upstream DNS server in ConfigFile.
+func SetServer(server string) error {
+	return updateConfigLine("server=", fmt.Sprintf("server=%s", server))
+}
+
+// SetPort updates listening port in ConfigFile.
+func SetPort(port int) error {
+	return updateConfigLine("port=", fmt.Sprintf("port=%d", port))
+}
+
+// updateConfigLine ensures the configuration file contains exactly one line
+// starting with prefix. Existing lines with the same prefix are removed before
+// the new line is appended.
+func updateConfigLine(prefix, line string) error {
+	var lines []string
+	if data, err := os.ReadFile(ConfigFile); err == nil {
+		for _, l := range strings.Split(string(data), "\n") {
+			if !strings.HasPrefix(l, prefix) && l != "" {
+				lines = append(lines, l)
+			}
+		}
+	}
+	lines = append(lines, line)
+	return os.WriteFile(ConfigFile, []byte(strings.Join(lines, "\n")+"\n"), 0644)
+}
+
+// removeConfigLine removes all lines starting with prefix from ConfigFile.
+func removeConfigLine(prefix string) error {
+	data, err := os.ReadFile(ConfigFile)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	var lines []string
+	if err == nil {
+		for _, l := range strings.Split(string(data), "\n") {
+			if !strings.HasPrefix(l, prefix) && l != "" {
+				lines = append(lines, l)
+			}
+		}
+	}
+	if len(lines) == 0 {
+		return os.Remove(ConfigFile)
+	}
+	return os.WriteFile(ConfigFile, []byte(strings.Join(lines, "\n")+"\n"), 0644)
+}


### PR DESCRIPTION
## Summary
- add dns package with dnsmasq config helpers
- support `kvasx dns set` CLI command
- drop unused `kvasx adblock` command and helpers

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689a335d26ac8332926ea73b7a555ecd